### PR TITLE
Enhance health bar visuals and preload attack images

### DIFF
--- a/game.js
+++ b/game.js
@@ -101,11 +101,11 @@
     const element = inferElementFromPrompt(raw);
     const isEffective = element === TYPE_WEAKNESS[enemyType];
 
-    // Create projectile and animate
+    // Create projectile and animate once its image has loaded
     attackInFlight = true;
     sendBtn.disabled = true;
 
-    const proj = createProjectile(raw, element);
+    const { el: proj, img } = createProjectile(raw, element);
     playfield.appendChild(proj);
 
     const { targetLeft, targetTop } = getDemonTargetPoint();
@@ -114,37 +114,40 @@
     proj.style.left = `${start.left}px`;
     proj.style.top = `${start.top}px`;
 
-    // Force layout so the initial position is applied before transition
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    proj.offsetHeight;
+    const launch = () => {
+      // Force layout so the initial position is applied before transition
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      proj.offsetHeight;
 
-    proj.style.transition = "left 1400ms cubic-bezier(.2,.65,.3,1), top 1400ms cubic-bezier(.2,.65,.3,1)";
-    proj.style.left = `${targetLeft}px`;
-    proj.style.top = `${targetTop}px`;
+      proj.style.transition = "left 1400ms cubic-bezier(.2,.65,.3,1), top 1400ms cubic-bezier(.2,.65,.3,1)";
+      proj.style.left = `${targetLeft}px`;
+      proj.style.top = `${targetTop}px`;
 
-    const onArrive = () => {
-      proj.removeEventListener("transitionend", onArrive);
-      spawnExplosionAt(targetLeft + proj.offsetWidth / 2, targetTop + proj.offsetHeight / 2);
-      proj.remove();
+      const onArrive = () => {
+        spawnExplosionAt(targetLeft + proj.offsetWidth / 2, targetTop + proj.offsetHeight / 2);
+        proj.remove();
 
-      if (isEffective) {
-        enemyHP = Math.max(0, enemyHP - DAMAGE_PER_HIT);
-      } else {
-        playerHP = Math.max(0, playerHP - DAMAGE_PER_HIT);
-        flashDamage();
-      }
+        if (isEffective) {
+          enemyHP = Math.max(0, enemyHP - DAMAGE_PER_HIT);
+        } else {
+          playerHP = Math.max(0, playerHP - DAMAGE_PER_HIT);
+          flashDamage();
+        }
 
-      updateBars();
-      attackInFlight = false;
-      if (!promptInput.classList.contains("has-banned")) {
-        sendBtn.disabled = false;
-      }
+        updateBars();
+        attackInFlight = false;
+        if (!promptInput.classList.contains("has-banned")) {
+          sendBtn.disabled = false;
+        }
 
-      if (enemyHP <= 0) return endGame(true);
-      if (playerHP <= 0) return endGame(false);
+        if (enemyHP <= 0) return endGame(true);
+        if (playerHP <= 0) return endGame(false);
+      };
+
+      proj.addEventListener("transitionend", onArrive, { once: true });
     };
 
-    proj.addEventListener("transitionend", onArrive);
+    loadProjectileImage(img, raw, launch);
 
     // Clear prompt for next input
     promptInput.value = "";
@@ -172,9 +175,7 @@
     el.className = `projectile ${elementClass(element)}`;
 
     const img = document.createElement("img");
-    const q = encodeURIComponent(text);
-    // Unsplash Source API provides keyword-based images without an API key
-    img.src = `https://source.unsplash.com/featured/72x72?${q}`;
+    // Source will be assigned once we attempt to load the image
     img.alt = text;
     img.referrerPolicy = "no-referrer";
     el.appendChild(img);
@@ -183,7 +184,30 @@
     label.className = "label";
     label.textContent = truncate(text, 22);
     el.appendChild(label);
-    return el;
+    return { el, img };
+  }
+
+  function loadProjectileImage(img, text, onReady) {
+    const q = encodeURIComponent(text);
+    const attempt = () => {
+      img.src = `https://source.unsplash.com/featured/72x72?${q}&sig=${Date.now()}`;
+    };
+    const handleLoad = () => {
+      if (img.naturalWidth === 0) {
+        attempt();
+        return;
+      }
+      cleanup();
+      onReady();
+    };
+    const handleError = () => attempt();
+    const cleanup = () => {
+      img.removeEventListener("load", handleLoad);
+      img.removeEventListener("error", handleError);
+    };
+    img.addEventListener("load", handleLoad);
+    img.addEventListener("error", handleError);
+    attempt();
   }
 
   function spawnExplosionAt(x, y) {
@@ -217,6 +241,9 @@
     const pPct = Math.round((playerHP / PLAYER_MAX_HP) * 100);
     enemyFill.style.width = `${ePct}%`;
     playerFill.style.width = `${pPct}%`;
+    playerFill.style.background = healthGradient(pPct);
+    enemyPts.style.color = ePct < 30 ? getCssVar("--danger") : getCssVar("--muted");
+    playerPts.style.color = pPct < 30 ? getCssVar("--danger") : getCssVar("--muted");
     enemyPts.textContent = `${enemyHP} / ${ENEMY_MAX_HP}`;
     playerPts.textContent = `${playerHP} / ${PLAYER_MAX_HP}`;
   }
@@ -281,6 +308,11 @@
   function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
   function clearChildren(node) { while (node.firstChild) node.removeChild(node.firstChild); }
   function getCssVar(name) { return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || "#fff"; }
+
+  function healthGradient(pct) {
+    const hue = (pct / 100) * 120;
+    return `linear-gradient(90deg, hsl(${hue}, 70%, 50%), hsl(${hue}, 70%, 65%))`;
+  }
 
   function showToast(message) {
     toast.textContent = message;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <div id="enemy-area">
           <div id="enemy">
             <div id="demon-sprite" aria-label="Demon" role="img">
-              <img src="assets/demon.svg" alt="Demon" />
+              <img src="./assets/demon.svg" alt="Demon" />
             </div>
             <div id="enemy-type-badge" title="Enemy type"><span id="enemy-type-emoji">🔥</span></div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,7 @@ body {
   height: 100%;
   width: 100%;
   background: linear-gradient(90deg, #6ee7b7, #10b981);
+  transition: width 300ms ease;
 }
 
 .health-points {


### PR DESCRIPTION
## Summary
- Animate health bar changes for smoother feedback
- Color player health bar based on remaining life and highlight low health values
- Load projectile image from Unsplash before allowing it to attack and retry until a valid image loads
- Restore demon sprite path so enemy is visible again

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db2b315b4832984a76ed33c04ccd3